### PR TITLE
Updated dependencies to latest versions and removed use of deprecated req.param.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ app.all('/ajaxsecure',ac.swapCode(SupportAJAX),ac.check(SupportAJAX),routes.secu
 ## Release History
 |Version|Date|Description|
 |:--:|:--:|:--|
+|v0.4.11|2020-03-04|Updated dependencies to latest versions and removed use of deprecated req.param|
 |v0.4.10|2018-02-27|Updated dependencies to latest versions |
 |v0.4.9|2017-06-19|Multiple API keys can be configured for various third parties |
 |v0.4.8|2017-05-16|Support authDetail object in the response so cater for conditional access |

--- a/lib/index.js
+++ b/lib/index.js
@@ -90,7 +90,7 @@ AC.prototype.swapCode = function(opt) {
     return function swapIt(req, res, next) {
         req.noRespond = opt.noRespond;
         req.tokenName = self.options.tokenName;
-        var authCode = req.param(self.options.authCode);
+        var authCode = req.params&&req.params[self.options.authCode] || req.body&&req.body[self.options.authCode] || req.query&&req.query[self.options.authCode];
         debug('swapCode() self.options.authCodename:%s authCode:%s scope:%s', self.options.authCode, authCode, self.scope);
         if (!authCode) {
             return next();
@@ -159,7 +159,6 @@ AC.prototype.check = function(opt) {
             redirectURL = redirectURL + req.protocol + '://' + req.get('host') + req.originalUrl;
         }
         res.locals.redirectURL = redirectURL;
-        debug('codeName:%s and code:%s', self.options.authCode, req.param(self.options.authCode));
         var token = getAuthHeader(req) || req[self.options.tokenName] || req.body&&req.body[self.options.tokenName] || req.query&&req.query[self.options.tokenName] || req.cookies&&req.cookies[self.options.tokenName] ;
         debug('cookieName:%s cookie:%s', self.options.tokenName, token)
         if (!token) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth-client",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "Checks Authorisation using tokens from a remote web server",
   "keywords": [
     "express",
@@ -29,8 +29,8 @@
   ],
   "main": "./lib",
   "dependencies": {
-    "request": "^2.37.0",
-    "debug": "^3.0.0"
+    "debug": "^4.1.0",
+    "request": "^2.88.2"
   },
   "devDependencies": {},
   "engines": {


### PR DESCRIPTION
The removed debug line with the req.param usage was redundant at this stage as the authCode is not used within this function.
The new logic to fetch authCode is similar to the way we fetch the token but mirrors the current order of the req.param function

